### PR TITLE
CI: Setup distributable binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,10 @@ jobs:
           brew cleanup --prune-prefix
           sudo rm -rf $(brew --repo homebrew/core)
 
+      # Build Homebrew recipe
+      - name: Build
+        run:  ./build.sh
+
       # Save distributable as Artifact
       - name: Save Distributable
         uses: actions/upload-artifact@v2
@@ -60,10 +64,6 @@ jobs:
           path: pkg/*.pkg
           retention-days: 1
           if-no-files-found: error
-          
-      # Build Homebrew recipe
-      - name: Build
-        run:  ./build.sh
 
       # Test Homebrew recipe
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,15 @@ jobs:
           brew cleanup --prune-prefix
           sudo rm -rf $(brew --repo homebrew/core)
 
+      # Save distributable as Artifact
+      - name: Save Distributable
+        uses: actions/upload-artifact@v2
+        with:
+          name: metacall
+          path: pkg/*.pkg
+          retention-days: 1
+          if-no-files-found: error
+          
       # Build Homebrew recipe
       - name: Build
         run:  ./build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Build and Test Homebrew MetaCall
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "v*.*.*"
   pull_request:
   workflow_dispatch:
 
@@ -56,15 +60,14 @@ jobs:
       - name: Build
         run:  ./build.sh
 
-      # Save distributable as Artifact
-      - name: Save Distributable
-        uses: actions/upload-artifact@v2
-        with:
-          name: metacall
-          path: pkg/*.pkg
-          retention-days: 1
-          if-no-files-found: error
-
       # Test Homebrew recipe
       - name: Test
         run: ./test.sh
+
+      # Release package
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          fail_on_unmatched_files: true
+          files: pkg/*.pkg

--- a/build.sh
+++ b/build.sh
@@ -10,3 +10,9 @@ fi
 # Build metacall brew recipe
 export HOMEBREW_NO_AUTO_UPDATE=1
 brew install ./metacall.rb --build-from-source --overwrite -v
+
+# Build distributable binary using brew pkg
+mkdir pkg && cd pkg
+brew tap timsutton/formulae
+brew install brew-pkg
+brew pkg --with-deps --without-kegs metacall


### PR DESCRIPTION
Update CI workflow to build distributable binary for the homebrew installation using [`brew pkg`](https://github.com/timsutton/brew-pkg).