### PR TITLE
Fixing python port issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,11 @@ if [[ $(command -v brew) == "" ]]; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+# Clean up previous installation
+brew uninstall --force metacall || true
+brew cleanup -s metacall
+brew cleanup --prune-prefix
+
 # Build metacall brew recipe
 export HOMEBREW_NO_AUTO_UPDATE=1
-brew install --formula ./metacall.rb --build-from-source --overwrite -v
+brew install ./metacall.rb --build-from-source --overwrite -v

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,6 @@ if [[ $(command -v brew) == "" ]]; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
-# Clean up previous installation
-brew uninstall --force metacall || true
-brew cleanup -s metacall
-brew cleanup --prune-prefix
-
 # Build metacall brew recipe
 export HOMEBREW_NO_AUTO_UPDATE=1
-brew install ./metacall.rb --build-from-source --overwrite -v
+brew install --formula ./metacall.rb --build-from-source --overwrite -v

--- a/metacall.rb
+++ b/metacall.rb
@@ -45,6 +45,12 @@ class Metacall < Formula
   end
 
   def install
+    # Create a directory for the Python module
+    py_module_dir = prefix/"lib/python"
+    mkdir_p py_module_dir
+    ENV["PIP_TARGET"] = py_module_dir.to_s
+    ENV.delete("PYTHONPATH")  # Clear PYTHONPATH to avoid conflicts
+  
     # Build path
     build_dir = buildpath/"build"
     Dir.mkdir(build_dir)
@@ -63,8 +69,7 @@ class Metacall < Formula
     py3pip = py3prefix/"lib/python#{py3ver}/site-packages"
 
     # Add pip site packages folder to target so the build system can find it
-    ENV.prepend_path "PIP_TARGET", py3pip
-
+  
     # Set NodeJS
     resource("node").stage do
       build_dir.install resource("node")
@@ -151,6 +156,7 @@ class Metacall < Formula
       "else\n",
       "  PREFIX=\"${PARENT}/Cellar/metacall/#{version}\"\n",
       "fi\n",
+      "export PYTHONPATH=\"${PREFIX}/lib/python:${PYTHONPATH:-}\"\n",
       "export NODE_PATH=#{HOMEBREW_PREFIX}/lib/node_modules\n",
       "export LOADER_LIBRARY=\"${PREFIX}/lib\"\n",
       "export SERIAL_LIBRARY_PATH=\"${PREFIX}/lib\"\n",


### PR DESCRIPTION
The issue was it was trying to install python module in the  site packages directory. 
And we don't have permission to write to this directory because we are using homebrew. 
So, I created a custom directory to installing the python module.
And then redirecting the installation there.


```
ERROR: Exception:
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/shutil.py", line 856, in move
    os.rename(src, real_dst)
    ~~~~~~~~~^^^^^^^^^^^^^^^
PermissionError: [Errno 1] Operation not permitted: '/private/tmp/pip-target-chlghnvn/lib/python/metacall' -> '/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/metacall'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/base_command.py", line 106, in _run_wrapper
    status = _inner_run()
  File "/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/base_command.py", line 97, in _inner_run
    return self.run(options, args)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.13/site-packages/pip/_internal/cli/req_command.py", line 67, in wrapper
    return func(self, options, args)
  File "/opt/homebrew/lib/python3.13/site-packages/pip/_internal/commands/install.py", line 520, in run
    self._handle_target_dir(
    ~~~~~~~~~~~~~~~~~~~~~~~^
        options.target_dir, target_temp_dir, options.upgrade
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
```